### PR TITLE
LUM-6034 if available, use the publication artifactId as the jar base…

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
 group=com.bancvue
 artifactId=gradle-core
-version=1.3-bb-1.0
+version=1.3-bb-1.1
 description=Gradle plugins for general project development

--- a/src/integrationTest/groovy/com/bancvue/gradle/maven/publish/MavenPublishExtPluginIntegrationSpecification.groovy
+++ b/src/integrationTest/groovy/com/bancvue/gradle/maven/publish/MavenPublishExtPluginIntegrationSpecification.groovy
@@ -136,6 +136,38 @@ publishing_ext {
 		assertArchiveBuiltAndUploadedToMavenRepo("artifact-custom", "sources")
 	}
 
+	def "should respect artifactId defined in extended publication block"() {
+		given:
+		emptyClassFile("src/custom/java/CustomClass.java")
+		setupLocalMavenRepoAndApplyPlugin()
+		buildFile << """
+configurations {
+	custom
+}
+
+sourceSets {
+	custom {
+		java {
+			srcDir 'src/custom/java'
+		}
+	}
+}
+
+publishing_ext {
+	publication("custom") {
+		artifactId = "custom-override"
+	}
+}
+"""
+
+		when:
+		run("publish")
+
+		then:
+		assertArchiveBuiltAndUploadedToMavenRepo("custom-override")
+		assertArchiveBuiltAndUploadedToMavenRepo("custom-override", "sources")
+	}
+
 	def "should use custom source set and configuration if configured"() {
 		given:
 		emptyClassFile("src/other/java/MainClass.java")

--- a/src/main/groovy/com/bancvue/gradle/maven/publish/ExtendedPublication.groovy
+++ b/src/main/groovy/com/bancvue/gradle/maven/publish/ExtendedPublication.groovy
@@ -132,21 +132,21 @@ class ExtendedPublication {
 	private Jar findOrCreateJarTask() {
 		resolveJarTask(
 				{ namer.jarTaskName },
-				{ CommonTaskFactory generator -> generator.createJarTask() }
+				{ CommonTaskFactory generator -> generator.createJarTask(artifactId) }
 		)
 	}
 
 	private Jar findOrCreateSourcesJarTask() {
 		resolveJarTask(
 				{ namer.sourcesJarTaskName },
-				{ CommonTaskFactory generator -> generator.createSourcesJarTask() }
+				{ CommonTaskFactory generator -> generator.createSourcesJarTask(artifactId) }
 		)
 	}
 
 	private Jar findOrCreateJavadocJarTask() {
 		resolveJarTask(
 				{ namer.javadocJarTaskName },
-				{ CommonTaskFactory generator -> generator.createJavadocJarTask() }
+				{ CommonTaskFactory generator -> generator.createJavadocJarTask(artifactId) }
 		)
 	}
 

--- a/src/main/groovy/com/bancvue/gradle/support/CommonTaskFactory.groovy
+++ b/src/main/groovy/com/bancvue/gradle/support/CommonTaskFactory.groovy
@@ -38,15 +38,15 @@ class CommonTaskFactory {
 		this.namer = namer
 	}
 
-	Jar createJarTask() {
-		createAndConfigureJarTask(namer.jarTaskName, sourceSet.output)
+	Jar createJarTask(String artifactId = null) {
+		createAndConfigureJarTask(namer.jarTaskName, artifactId, sourceSet.output)
 	}
 
-	Jar createSourcesJarTask() {
-		createAndConfigureJarTask(namer.sourcesJarTaskName, sourceSet.allSource, "sources")
+	Jar createSourcesJarTask(String artifactId = null) {
+		createAndConfigureJarTask(namer.sourcesJarTaskName, artifactId, sourceSet.allSource, "sources")
 	}
 
-	private Jar createAndConfigureJarTask(String jarTaskName, Object sourcePath, String classifierString = null) {
+	private Jar createAndConfigureJarTask(String jarTaskName, String artifactId, Object sourcePath, String classifierString = null) {
 		String postfix = namer.sourceSetNameAppendix
 		String jarContent = classifierString ? classifierString : "classes"
 		Jar jarTask = project.tasks.create(jarTaskName, Jar)
@@ -56,7 +56,9 @@ class CommonTaskFactory {
 			if (classifierString) {
 				classifier = classifierString
 			}
-			if (postfix) {
+			if (artifactId) {
+				baseName = artifactId
+			} else if (postfix) {
 				baseName = "${baseName}-${postfix}"
 			}
 			from sourcePath
@@ -64,12 +66,12 @@ class CommonTaskFactory {
 		jarTask
 	}
 
-	Jar createJavadocJarTask() {
+	Jar createJavadocJarTask(String artifactId = null) {
 		Javadoc javadocTask = project.tasks.findByName(namer.javadocTaskName)
 		if (javadocTask == null) {
 			javadocTask = createJavadocTask()
 		}
-		Jar javadocJarTask = createAndConfigureJarTask(namer.javadocJarTaskName, javadocTask.destinationDir, "javadoc")
+		Jar javadocJarTask = createAndConfigureJarTask(namer.javadocJarTaskName, artifactId, javadocTask.destinationDir, "javadoc")
 		javadocJarTask.dependsOn { javadocTask }
 		javadocJarTask
 	}


### PR DESCRIPTION
… name

@blackbaud/luminate-leads 

The jar names are not respecting artifactId overrides - until this is merged, the work done for https://jira.blackbaud.com/browse/LUM-6034 will not catch all dependencies (any of the clients defined in core, common-spring-boot-rest-test, etc)
